### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "eslint-plugin-jsdoc": "^37.0.3",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",
-    "eslint-plugin-standard": "^5.0.0",
     "husky": "^7.0.2",
     "jest": "^27.0.4",
     "jest-environment-jsdom-latest": "^26.6.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/NickDJM/accessible-menu-bootstrap-4#readme",
   "dependencies": {
-    "accessible-menu": "^3.0.3"
+    "accessible-menu": "^3.0.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",


### PR DESCRIPTION
## Description

I want to make sure 3.0.3 isn't used for accessible-menu since it's bugged.