### PR TITLE
docs: remove live examples because they only support BS5 now

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ const menu = new Bootstrap4Treeview({
   - [Single-level menu](docs/basics/single-level-menu.md)
   - [Single-level menu with toggle](docs/basics/single-level-menu-with-toggle.md)
   - [Two-level menu with toggle](docs/basics/two-level-menu-with-toggle.md)
-- [Live examples](https://mandrasch.github.io/accessible-menu-bootstrap-examples/)
 
 ### Conflict with Bootstrap's own navbar toggle
 


### PR DESCRIPTION
See #24
