### PR TITLE
build(npm): require at least accessible-menu v3.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/NickDJM/accessible-menu-bootstrap-4#readme",
   "dependencies": {
-    "accessible-menu": "^3.0.4"
+    "accessible-menu": "^3.0.7"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",

--- a/tests/menus/_common/aria.js
+++ b/tests/menus/_common/aria.js
@@ -1,6 +1,5 @@
 /**
  * Reusable ARIA tests.
- *
  * @jest-environment jsdom
  */
 /* eslint-disable no-new */
@@ -9,7 +8,6 @@ import { twoLevelMenu } from "./test-menus";
 
 /**
  * A set of ARIA tests.
- *
  * @param {(typeof Bootstrap4DisclosureMenu|typeof Bootstrap4Menubar|typeof Bootstrap4Treeview)} MenuClass - The menu class to test.
  */
 export function aria(MenuClass) {
@@ -79,7 +77,7 @@ export function aria(MenuClass) {
         );
 
         if (menuType === "Bootstrap4Menubar") {
-          expect(submenuElement.getAttribute("role")).toBe("menubar");
+          expect(submenuElement.getAttribute("role")).toBe("menu");
         } else if (menuType === "Bootstrap4Treeview") {
           expect(submenuElement.getAttribute("role")).toBe("group");
         }


### PR DESCRIPTION
## Related Issues

https://github.com/NickDJM/accessible-menu-bootstrap-5/issues/62
